### PR TITLE
support protoc with mac m1 aarch

### DIFF
--- a/network/pom.xml
+++ b/network/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.17.3</version>
+            <version>3.18.1</version>
         </dependency>
         <dependency>
             <groupId>com.alipay.sofa</groupId>
@@ -57,7 +57,7 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <protocVersion>3.11.4</protocVersion>
+                            <protocVersion>3.18.1</protocVersion>
                             <inputDirectories>
                                 <include>src/main/protobuf</include>
                             </inputDirectories>


### PR DESCRIPTION
support protoc with mac m1 aarch
update protobuf-java version: 3.17 -> 3.18.1
update protoc plugin version: 3.11.4 -> 3.18.1